### PR TITLE
fixed the nmake build; added brief installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ set of patterns established by the core Tcl commands, is terse and
 readable to specify the arguments, and is fast enough to use in any
 situation.
 
+# INSTALLATION
+Common note: make sure to clone the repository with the `--recurse-submodules` option in order to pull the `tclconfig` submodule.
+## Linux
+Make sure you have both `tcl` and `tcl-devel` packages installed.
+```sh
+autoreconf
+# customize with the correct Tcl paths in your system
+./configure --with-tcl=/usr/lib64  --with-tclinclude=/usr/include
+# "make all" will generate documentation using pandoc
+make 
+sudo make install
+# or you can skip the documentation:
+make binaries
+sudo make install-binaries
+```
+## Windows
+You can build the package using `nmake` in your MSVC shell. Customize INSTALLDIR to your Tcl location.
+```cmd
+cd parse_args\win
+nmake /nologo /f makefile.vc INSTALLDIR=c:\software\ActiveTcl_8.6.12
+nmake /nologo /f makefile.vc INSTALLDIR=c:\software\ActiveTcl_8.6.12 install
+```
 # COMMANDS
 
   - **parse\_args::parse\_args** *args* *argspec*  

--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -19,8 +19,7 @@ PROJECT = parse_args
 !include "rules-ext.vc"
 
 PRJ_OBJS = $(TMP_DIR)\parse_args.obj
-
-# PRJ_DEFINES = -D_CRT_SECURE_NO_WARNINGS
+PRJ_DEFINES = -DTIP445_SHIM -D_CRT_SECURE_NO_WARNINGS
 
 !include "$(_RULESDIR)\targets.vc"
 


### PR DESCRIPTION
Re. makefile.vc: although it would be nice to detect if tip445.h needs to be included, TBH I'm not a big expert in nmake files. Considering that this TIP is not merged yet into Tcl 8.6 or 8.7-alpha, I suppose I can just define TIP445_SHIM unconditionally. Also I've added brief installation instructions for both Linux and Windows - please feel free to edit them. 

P.S. wow I see you support even Tcl 9... is anyone using it in production? o_O